### PR TITLE
Adjust DateTime.utc to DateTime.new_offset

### DIFF
--- a/lib/solar/support.rb
+++ b/lib/solar/support.rb
@@ -19,14 +19,14 @@ module Solar
       else
         # This preserves the internal precision of t (which we probably don't need)
         # and produces larger denominators in general
-        t.to_datetime.utc.ajd
+        t.to_datetime.new_offset.ajd
       end
     end
 
     # Julian Day as Float
     def jd_f(t)
       # t.to_date.ajd.to_f + t.hour/24.0 + t.min/1440.0 + t.sec/86400.0
-      t.to_datetime.utc.ajd.to_f
+      t.to_datetime.new_offset.ajd.to_f
     end
 
     def to_rad(deg)


### PR DESCRIPTION
In Ruby 2.5.1 DateTime.utc returns a Time object, which doesn't have the method ajd. By using new_offset without any arguments the timezone is changed to UTC like before, but it returns a DateTime object instead.